### PR TITLE
Hide wind direction textual value

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                         </ul>
                     </div>
 
-                    <div class="margin value-font"><span lang="en">Wind direction: </span><span lang="ru">Направление ветра: </span><span id="wind-direction-value"></span></div>
+                    <div class="margin value-font"><span lang="en">Wind direction: </span><span lang="ru">Направление ветра: </span><span id="wind-direction-value" style="display:none"></span></div>
                     <div id="wind-direction-slider" class="small-margin"></div>
                     <div class="margin value-font"><span lang="en">Wind speed: </span><span lang="ru">Скорость ветра: </span><span id="wind-speed-value"></span></div>
                     <div id="wind-speed-slider" class="small-margin"></div>


### PR DESCRIPTION
People seem to get confused about this wind direction textual value and navigational/meteorological distinction.

Maybe we should remove it alltogether? What do you think, @hr0nix?
